### PR TITLE
Adding Learn, Workshops categories and content

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,24 +5,33 @@
 
 ## Contents
 
-- [Section](#section)
-- [Another Section](#another-section)
+- [Learn](#learn)
+  - [Git](#git)
+- [Workshops](#workshops)
+  - [Tips](#tips)
+  - [Slide Resources](#slide-resources)
 
 
-## Section
+## Learn
 
-About this section. Optional. Keep this short and focus on the list.
+Resources for learning or teaching languages, techniques, skills etc.
 
-- [List item](http://example.com)
-- [List item](http://example.com)
+### Git
+
+- [Learn Git Branching](http://learngitbranching.js.org/) - Interactive lesson which visualises branches and commits
 
 
-## Another Section
+## Workshops
 
-### Subsection
+Resources for running workshops and workshops that other campus experts have run themselves or that may be useful to others.
 
-- [List item](http://example.com)
-- [List item](http://example.com)
+### Tips
+
+- [Speaking.io](http://speaking.io/) - a cool website with some good tips on giving talks, focused on tech talks mostly
+
+
+### Slide Resources
+- [FsReveal](https://github.com/fsprojects/FsReveal) - FsReveal allows you to write beautiful slides in Markdown and brings F# to the reveal.js web presentation framework.
 
 
 ## Contribute


### PR DESCRIPTION
### Categories

Added 2 new categories
- Learn
- Workshops

Learn is for learning or teaching languages, techniques, skills etc.

Workshops are resources for running workshops and workshops that other campus experts have run themselves or that may be useful to others.

### Content

#### Learn > Git

Found this gem on the [GitHub education community 
](https://education.github.community/t/how-do-you-introduce-git-in-your-course/10583). Super awesome interactive tool which visualises branching.

#### Workshops

These were suggested by @BlueHatbRit over on the[ spring-2017 repo ](https://github.com/campus-experts/spring-2017/issues/19)


