### PR TITLE
Fix bullet point on a community link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ Communication and writing style
 ## Community
 
 ### Management
--[Curriculum for the Atom Community Manager Apprenticeship project](https://github.com/lee-dohm/community-manager)
+- [Curriculum for the Atom Community Manager Apprenticeship project](https://github.com/lee-dohm/community-manager)
 
 
 ## Contribute


### PR DESCRIPTION
The dash before `Curriculum for the Atom Community Manager Apprenticeship project` was missing a space before the content which I've added. It should now render properly on github.