### PR TITLE
Add mdpdf and tryGit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ Resources for learning or teaching languages, techniques, skills etc.
 
 ### Git
 
+- [tryGit](https://try.github.io/levels/1/challenges/1) - A 15 minute introduction to git in the terminal.
 - [Learn Git Branching](http://learngitbranching.js.org/) - Interactive lesson which visualises branches and commits
 - [GitHub Flow](https://guides.github.com/introduction/flow/) - Guide that explains how and why GitHub Flow work
 - [On Demand Training](https://services.github.com/on-demand/) - On demand training material for various Git and GitHub tools such a command line and GitHub Pages
@@ -65,6 +66,7 @@ Resources for writing and maintaining technical documentation
 - [nanoc](https://nanoc.ws/) - Nanoc is a static-site generator, fit for building anything from a small personal blog to a large corporate website. (used by GitHub on their own docs)
 - [Sphinx](http://www.sphinx-doc.org/en/stable/) - Sphinx is a tool that makes it easy to create intelligent and beautiful documentation, originally created for the Python documentation.
 - [Daux](https://github.com/justinwalsh/daux.io) - Daux is an documentation generator that uses a simple folder structure and Markdown files to create custom documentation on the fly.
+- :triangular_flag_on_post: [mdpdf](https://github.com/bluehatbrit/mdpdf) - mdpdf is a tool for generating stylable pdfs from markdown.
 
 ### Content Guides
 


### PR DESCRIPTION
A bit of shameless self promotion and also a genuine add:

* mdpdf is a tool for converting markdown files into pdfs. Really great if you want to version control a document but be able to print / send it around as a pdf. (Codes of conduct, as well as essays etc).
* tryGit is the github tool for a "15 minute introduction to git". I've put this one at the top as it's aimed towards someone who knows nothing about git so I think it's a good intro resource.