### PR TITLE
Add mocha test to check validity of all external links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "7"
+
+branches:
+  only:
+    - master

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "awesome-campus-expert",
+  "version": "1.0.0",
+  "description": "A curated list of awesome resources for GitHub Campus Experts",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "mocha './test/**/*_spec.js'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/campus-experts/awesome-campus-expert.git"
+  },
+  "author": "GitHub Campus Experts",
+  "license": "UNLICENSED",
+  "bugs": {
+    "url": "https://github.com/campus-experts/awesome-campus-expert/issues"
+  },
+  "homepage": "https://github.com/campus-experts/awesome-campus-expert#readme",
+  "devDependencies": {
+    "async": "^2.4.0",
+    "link-check": "^4.0.2",
+    "lodash": "^4.17.4",
+    "markdown-link-extractor": "^1.1.0",
+    "mocha": "^3.4.1",
+    "should": "^11.2.1"
+  }
+}

--- a/test/list_spec.js
+++ b/test/list_spec.js
@@ -1,0 +1,33 @@
+const path = require('path');
+const fs = require('fs');
+const should = require('should');
+const checkExternalLinks = require('./utils/external-link-checker');
+
+describe('Awesome list', function() {
+
+    describe('links', function() {
+
+        it('should all be valid', function(done) {
+            // Each link will be tested over http which
+            // can take quite a while.
+            this.timeout(15000);
+
+            const listPath = path.resolve(__dirname, '../readme.md');
+
+            fs.readFile(listPath, 'utf8', function(err, markdown) {
+                if (err) return done(err);
+
+                checkExternalLinks(markdown, function(err, results) {
+                    if (err) return done(err);
+                    
+                    results.forEach(function(result) {
+                        result.statusCode.should.equal(200);
+                        result.status.should.equal('alive');
+                    });
+
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/test/utils/external-link-checker.js
+++ b/test/utils/external-link-checker.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const _ = require('lodash');
+const async = require('async');
+const linkCheck = require('link-check');
+const markdownLinkExtractor = require('markdown-link-extractor');
+
+module.exports = function checkExternalLinks(markdown, opts, callback) {
+    if (arguments.length === 2 && typeof opts === 'function') {
+        callback = opts;
+        opts = {};
+    }
+
+    let links = _.uniq(markdownLinkExtractor(markdown));
+    // linkCheck will only check external links
+    let externalLinks = links.filter(function(link) {
+        return link.startsWith('http');
+    });
+
+    async.mapLimit(externalLinks, 2, function(link, callback) {
+        linkCheck(link, opts, callback);
+    }, callback);
+};


### PR DESCRIPTION
I've created a package.json with some relevant information to enable us to run it as a normal node project on travis later on. I've added a couple libraries including mocha and should, and I've created a test for all external links. The original proposed library had to be ditched as it would try to check relative and anchor links which isn't so helpful right now.

I've also just added a `.travis.yml` file, if we enable builds on "Branch Updates" and "Pull Requests" then it'll build all PR pushes once plus merges into master as we want.

The tests are quite quick right now so I suggest we include them in the PR process for now.

## Notes:

* In the package.json I listed the project as "UNLICENSED" as we don't have a license right now. Do we want to consider adding one now or in the future?
* I've set the author as "GitHub Campus Experts" with no email address for now rather than forcing responsibility onto someone.

This implements #12, cc @PandelisZ & @joenash