### PR TITLE
Add GitHub Pages to "Tools" Subsection

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ Resources for writing and maintaining technical documentation
 ### Tools
 
 - [nanoc](https://nanoc.ws/) - Nanoc is a static-site generator, fit for building anything from a small personal blog to a large corporate website. (used by GitHub on their own docs)
+- [GitHub Pages](https://pages.github.com/) - GitHub Pages is a tool that allows website hosting to occur directly through GitHub's free service.
 - [Sphinx](http://www.sphinx-doc.org/en/stable/) - Sphinx is a tool that makes it easy to create intelligent and beautiful documentation, originally created for the Python documentation.
 - [Daux](https://github.com/justinwalsh/daux.io) - Daux is an documentation generator that uses a simple folder structure and Markdown files to create custom documentation on the fly.
 - :triangular_flag_on_post: [mdpdf](https://github.com/bluehatbrit/mdpdf) - mdpdf is a tool for generating stylable pdfs from markdown.


### PR DESCRIPTION
The GitHub Pages is useful for communities just sprouting up and looking for a way to create and host websites to spread the word.